### PR TITLE
add wordpress example

### DIFF
--- a/chef-wordpress/Berksfile
+++ b/chef-wordpress/Berksfile
@@ -1,0 +1,12 @@
+source "https://supermarket.getchef.com"
+
+cookbook 'apt'
+cookbook 'os-hardening', git: 'https://github.com/dev-sec/chef-os-hardening.git'
+cookbook 'ssh-hardening', git: 'https://github.com/dev-sec/chef-ssh-hardening.git'
+cookbook 'mysql' , "5.5.2"
+cookbook 'mysql-chef_gem' , "0.0.5"
+cookbook 'database' , "2.3.1"
+cookbook 'nginx'
+cookbook 'nginx-hardening', git: 'https://github.com/dev-sec/chef-nginx-hardening.git'
+cookbook 'mysql-hardening', git: 'https://github.com/dev-sec/chef-mysql-hardening.git'
+cookbook 'wordpress' , "2.3.0"

--- a/chef-wordpress/LICENSE
+++ b/chef-wordpress/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/chef-wordpress/README.md
+++ b/chef-wordpress/README.md
@@ -1,0 +1,50 @@
+# wordpress hardening kitchen
+
+Demonstrates the use of the hardening cookbooks via Chef to increase the security of your server. It also captures the best practice for using multiple hardening modules.
+
+This example installs the following hardening modules:
+
+- [chef-os-hardening](https://github.com/dev-sec/chef-os-hardening)
+- [chef-ssh-hardening](https://github.com/dev-sec/chef-ssh-hardening)
+- [chef-mysql-hardening](https://github.com/dev-sec/chef-mysql-hardening)
+- [chef-nginx-hardening](https://github.com/dev-sec/chef-nginx-hardening)
+
+## Use with vagrant
+
+### Prerequisites
+
+ - Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+ - Install [Vagrant](https://www.vagrantup.com/downloads.html)
+ - Install [ChefDK](https://downloads.getchef.com/chef-dk)
+ - Install Vagrant Berkshelf via `vagrant plugin install vagrant-berkshelf`
+ - Install Vagrant Omnibus via `vagrant plugin install vagrant-omnibus`
+
+### Start
+
+```bash
+vagrant up
+open http://localhost:8082
+```
+
+## Use with knife solo
+
+### Prerequisites
+
+ - Install [ChefDK](https://downloads.getchef.com/chef-dk)
+ - Install knife-solo via `gem install knife-solo`
+
+## License and Author
+
+* Author:: Christoph Hartmann <chris@lollyrock.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/chef-wordpress/Vagrantfile
+++ b/chef-wordpress/Vagrantfile
@@ -1,0 +1,24 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "bento/ubuntu-12.04"
+
+  # forward port 80 to 8080 on host machine
+  config.vm.network "forwarded_port", guest: 80, host: 8082
+  config.vm.network "private_network", type: "dhcp"
+
+  # ensure chef is install in vm
+  config.omnibus.chef_version = "12.5.1"
+
+  # download all required cookbooks
+  config.berkshelf.enabled = true
+
+  # deployed chef roles
+  config.vm.provision "chef_solo" do |chef|
+    chef.roles_path = "roles"
+    chef.add_role("wordpress")
+  end
+end

--- a/chef-wordpress/roles/wordpress.json
+++ b/chef-wordpress/roles/wordpress.json
@@ -1,0 +1,30 @@
+{
+    "name": "wordpress",
+    "default_attributes": { },
+    "override_attributes": { },
+    "json_class": "Chef::Role",
+    "description": "Wordpress Role",
+    "chef_type": "role",
+    "default_attributes" : {
+      "php" :{
+        "tmpfs" : false,
+        "use_atomic_repo" : false
+      },
+      "nginx" : {
+        "repo_source" : "nginx",
+        "default_site_enabled" : false,
+        "client_max_body_size" : "50M"
+      },
+      "mysql": {
+        "server_root_password":  "iloverandompasswordsbutthiswilldo"
+      }
+    },
+    "run_list": [
+        "recipe[apt]",
+        "recipe[os-hardening]",
+        "recipe[ssh-hardening]",
+        "recipe[wordpress::nginx]",
+        "recipe[mysql-hardening]",
+        "recipe[nginx-hardening]"
+    ]
+}


### PR DESCRIPTION
This PR replaces https://github.com/dev-sec/example-chef-wordpress-hardening and adds this example. Once this PR is merged, the original repository can be merged
